### PR TITLE
Unsaved files dialog & Load Rom rename

### DIFF
--- a/editionmode.cpp
+++ b/editionmode.cpp
@@ -23,9 +23,11 @@ void ObjectsEditonMode::mousePressEvent(QMouseEvent *evt)
 
     if (evt->buttons() == Qt::RightButton)
     {
+
         selectionHasBGDats = false;
         selectedObjects.clear();
 
+        //tileset tab
         if (drawType == 0)
         {
             int id = selTileset << 12;
@@ -34,6 +36,7 @@ void ObjectsEditonMode::mousePressEvent(QMouseEvent *evt)
             level->objects[selLayer].append(bgdatobj);
             newObject = bgdatobj;
             paintingNewObject = true;
+            editMade = true;
         }
         else if (drawType == 1)
         {
@@ -41,13 +44,17 @@ void ObjectsEditonMode::mousePressEvent(QMouseEvent *evt)
             spr->setRect();
             level->sprites.append(spr);
             selectedObjects.append(spr);
+            editMade = true;
         }
+
+        //location tab
         else if (drawType == 4)
         {
             Location* loc = new Location(toNext16Compatible(evt->x()), toNext16Compatible(evt->y()), 4, 4, 0);
             level->locations.append(loc);
             newObject = loc;
             paintingNewObject = true;
+            editMade = true;
         }
     }
 
@@ -128,6 +135,8 @@ void ObjectsEditonMode::mouseMoveEvent(QMouseEvent *evt)
             else if (finalY > 0xFFFF*20) finalY = 0xFFFF*20;
 
             obj->setPosition(finalX, finalY);
+
+            editMade = true;
         }
 
         return;
@@ -152,6 +161,8 @@ void ObjectsEditonMode::mouseMoveEvent(QMouseEvent *evt)
 
         newObject->setPosition(qMin(x, mX), qMin(y, mY));
         newObject->resize(w,h);
+
+        editMade = true;
 
         return;
     }
@@ -235,4 +246,9 @@ void ObjectsEditonMode::setDrags()
         if (obj->getx() > maxSelX) maxSelX = obj->getx();
         if (obj->gety() > maxSelY) maxSelY = obj->gety();
     }
+}
+
+bool ObjectsEditonMode::getEditStatus()
+{
+    return editMade;
 }

--- a/editionmode.h
+++ b/editionmode.h
@@ -16,6 +16,8 @@ public:
     virtual void mouseMoveEvent(QMouseEvent *) {}
     virtual void deleteAction() {}
 
+    void wasEditMade();
+
 protected:
     Level* level;
 
@@ -40,6 +42,8 @@ public:
     void setLayer(int selLayer) { this->selLayer = selLayer; }
     void setSprite(int selSprite) { this->selSprite = selSprite; }
 
+    bool getEditStatus();
+
 private:
     int dx, dy;     // Last Click Position
     int lx, ly;     // Last Mouse Position
@@ -62,6 +66,8 @@ private:
     int selTileset;
     int selSprite;
     // TODO: etc
+
+    bool editMade = false;
 };
 
 #endif // EDITIONMODE_H

--- a/leveleditorwindow.cpp
+++ b/leveleditorwindow.cpp
@@ -328,11 +328,9 @@ void LevelEditorWindow::setSelSprite(int spriteId)
 
 void LevelEditorWindow::closeEvent(QCloseEvent *event)
 {
-    /* Unsaved changes debugging
     qDebug() << "Did save: " << didSave;
     qDebug() << "Level Window edit made: " << editMade;
     qDebug() << "Level View edit made: " << levelView->objEditionModePtr()->getEditStatus();
-    */
 
     //if no edits were made
     if(editMade == false && levelView->objEditionModePtr()->getEditStatus() == false)
@@ -340,7 +338,7 @@ void LevelEditorWindow::closeEvent(QCloseEvent *event)
 
     //if user did save
     //hack: getEditStatus can also be used to get the save status
-    else if(didSave == true && levelView->objEditionModePtr()->getEditStatus() == false)
+    else if(didSave == true)
         event->accept();
 
     else

--- a/leveleditorwindow.cpp
+++ b/leveleditorwindow.cpp
@@ -328,14 +328,19 @@ void LevelEditorWindow::setSelSprite(int spriteId)
 
 void LevelEditorWindow::closeEvent(QCloseEvent *event)
 {
-    qDebug() << didSave;
-    qDebug() << editMade;
-    qDebug() << levelView->getEditStatus();
+    /* Unsaved changes debugging
+    qDebug() << "Did save: " << didSave;
+    qDebug() << "Level Window edit made: " << editMade;
+    qDebug() << "Level View edit made: " << levelView->objEditionModePtr()->getEditStatus();
+    */
 
-    if(didSave == true && levelView->getSaveStatus() == true)
+    //if no edits were made
+    if(editMade == false && levelView->objEditionModePtr()->getEditStatus() == false)
         event->accept();
 
-    else if(editMade == false && levelView->getEditStatus() == false)
+    //if user did save
+    //hack: getEditStatus can also be used to get the save status
+    else if(didSave == true && levelView->objEditionModePtr()->getEditStatus() == false)
         event->accept();
 
     else
@@ -358,4 +363,5 @@ void LevelEditorWindow::closeEvent(QCloseEvent *event)
                 break;
         }
     }
+    return;
 }

--- a/leveleditorwindow.cpp
+++ b/leveleditorwindow.cpp
@@ -24,6 +24,7 @@
 #include <QHBoxLayout>
 #include <QSizePolicy>
 #include <QStandardItemModel>
+#include <QMessageBox>
 
 LevelEditorWindow::LevelEditorWindow(QWidget *parent, Level* level) :
     QMainWindow(parent),
@@ -237,6 +238,7 @@ void LevelEditorWindow::on_actionZoom_Minimum_triggered()
 void LevelEditorWindow::on_actionSave_triggered()
 {
     levelView->saveLevel();
+    didSave = true;
 }
 
 void LevelEditorWindow::on_actionCopy_triggered()
@@ -247,16 +249,19 @@ void LevelEditorWindow::on_actionCopy_triggered()
 void LevelEditorWindow::on_actionPaste_triggered()
 {
     levelView->paste();
+    editMade = true;
 }
 
 void LevelEditorWindow::on_actionCut_triggered()
 {
     levelView->cut();
+    editMade = true;
 }
 
 void LevelEditorWindow::on_actionDelete_triggered()
 {
     levelView->deleteSel();
+    editMade = true;
 }
 
 void LevelEditorWindow::on_actionFullscreen_toggled(bool toggle)
@@ -316,4 +321,38 @@ void LevelEditorWindow::setSelSprite(int spriteId)
 {
     levelView->objEditionModePtr()->setDrawType(1);
     levelView->objEditionModePtr()->setSprite(spriteId);
+}
+
+void LevelEditorWindow::closeEvent(QCloseEvent *event)
+{
+    qDebug() << didSave;
+    qDebug() << editMade;
+    qDebug() << levelView->getEditStatus();
+
+    if(didSave == true)
+        event->accept();
+
+    else if(editMade == false && levelView->getEditStatus() == false)
+        event->accept();
+
+    else
+    {
+        QMessageBox message(this);
+        message.setWindowTitle("Unsaved Changes");
+        message.setText("You didn't save your level!");
+        message.setStandardButtons(QMessageBox::Save | QMessageBox::Cancel | QMessageBox::Discard);
+        switch (message.exec())
+        {
+            case QMessageBox::Save:
+                levelView->saveLevel();
+                event->accept();
+                break;
+            case QMessageBox::Cancel:
+                event->ignore();
+                break;
+            case QMessageBox::Discard:
+                event->accept();
+                break;
+        }
+    }
 }

--- a/leveleditorwindow.cpp
+++ b/leveleditorwindow.cpp
@@ -250,18 +250,21 @@ void LevelEditorWindow::on_actionPaste_triggered()
 {
     levelView->paste();
     editMade = true;
+    didSave = false;
 }
 
 void LevelEditorWindow::on_actionCut_triggered()
 {
     levelView->cut();
     editMade = true;
+    didSave = false;
 }
 
 void LevelEditorWindow::on_actionDelete_triggered()
 {
     levelView->deleteSel();
     editMade = true;
+    didSave = false;
 }
 
 void LevelEditorWindow::on_actionFullscreen_toggled(bool toggle)
@@ -329,7 +332,7 @@ void LevelEditorWindow::closeEvent(QCloseEvent *event)
     qDebug() << editMade;
     qDebug() << levelView->getEditStatus();
 
-    if(didSave == true)
+    if(didSave == true && levelView->getSaveStatus() == true)
         event->accept();
 
     else if(editMade == false && levelView->getEditStatus() == false)

--- a/leveleditorwindow.h
+++ b/leveleditorwindow.h
@@ -101,6 +101,11 @@ private:
     float zoom;
 
     void setupObjectsModel(int tilesetNbr);
+    void closeEvent(QCloseEvent *event);
+
+    bool didSave = false;
+
+    bool editMade = false;
 };
 
 #endif // LEVELEDITORWINDOW_H

--- a/levelview.cpp
+++ b/levelview.cpp
@@ -317,6 +317,7 @@ void LevelView::mousePressEvent(QMouseEvent* evt)
     update();
 
     editMade = true;
+    didSave = false;
 }
 
 
@@ -431,4 +432,9 @@ void LevelView::deleteSel()
 bool LevelView::getEditStatus()
 {
     return editMade;
+}
+
+bool LevelView::getSaveStatus()
+{
+    return didSave;
 }

--- a/levelview.cpp
+++ b/levelview.cpp
@@ -315,6 +315,8 @@ void LevelView::mousePressEvent(QMouseEvent* evt)
 {    
     objectEditionMode.mousePressEvent(evt);
     update();
+
+    editMade = true;
 }
 
 
@@ -424,4 +426,9 @@ void LevelView::deleteSel()
 {
     objectEditionMode.deleteAction();
     update();
+}
+
+bool LevelView::getEditStatus()
+{
+    return editMade;
 }

--- a/levelview.cpp
+++ b/levelview.cpp
@@ -315,9 +315,6 @@ void LevelView::mousePressEvent(QMouseEvent* evt)
 {    
     objectEditionMode.mousePressEvent(evt);
     update();
-
-    editMade = true;
-    didSave = false;
 }
 
 
@@ -427,14 +424,4 @@ void LevelView::deleteSel()
 {
     objectEditionMode.deleteAction();
     update();
-}
-
-bool LevelView::getEditStatus()
-{
-    return editMade;
-}
-
-bool LevelView::getSaveStatus()
-{
-    return didSave;
 }

--- a/levelview.h
+++ b/levelview.h
@@ -77,8 +77,6 @@ private:
     TileGrid tileGrid;
 
     bool editMade = false;
-
-    bool didSave = false;
 };
 
 #endif // LEVELVIEW_H

--- a/levelview.h
+++ b/levelview.h
@@ -46,6 +46,8 @@ public:
 
     bool getEditStatus();
 
+    bool getSaveStatus();
+
 signals:
 
 public slots:
@@ -75,6 +77,8 @@ private:
     TileGrid tileGrid;
 
     bool editMade = false;
+
+    bool didSave = false;
 };
 
 #endif // LEVELVIEW_H

--- a/levelview.h
+++ b/levelview.h
@@ -44,6 +44,8 @@ public:
 
     ObjectsEditonMode* objEditionModePtr() { return &objectEditionMode; }
 
+    bool getEditStatus();
+
 signals:
 
 public slots:
@@ -71,6 +73,8 @@ private:
 
     // determines which tiles are already occupied
     TileGrid tileGrid;
+
+    bool editMade = false;
 };
 
 #endif // LEVELVIEW_H

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -136,7 +136,7 @@
   <widget class="QStatusBar" name="statusBar"/>
   <action name="actionLoadROM">
    <property name="text">
-    <string>Load ROM (.3ds / .cia)</string>
+    <string>Load ROMFS Folder</string>
    </property>
   </action>
   <action name="actionAbout">


### PR DESCRIPTION
![screenshot](http://i.imgur.com/bRMonas.png)
Things that will trigger are:
- The cut button
- The paste button
- The delete button
- Clicking anywhere in the level view

Also, under File, it now says "Load ROMFS Folder" instead of "Load 3DS Rom (.3ds/.cia)", since it's loading a folder.
