### PR TITLE
Fixed Giant Dry Bones

### DIFF
--- a/objectrenderer.cpp
+++ b/objectrenderer.cpp
@@ -122,7 +122,7 @@ SpriteRenderer::SpriteRenderer(const Sprite *spr)
         ret = new NormalImageRenderer(spr, basePath + "dry_bones.png");
         break;
     case 111: // Giant Dry Bones
-        ret = new NormalImageRenderer(spr, basePath + "sgiant_dry_bones.png");
+        ret = new NormalImageRenderer(spr, basePath + "giant_dry_bones.png");
         break;
     case 114: // Floating Box
         ret = new FloatingBoxRenderer(spr);


### PR DESCRIPTION
Fixed a spelling error that prevented the sprite icon for Giant Dry Bones from showing up.
