### PR TITLE
Show in File Explorer context menu option

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -526,16 +526,17 @@ void MainWindow::createLevelListContextMenu(const QPoint &pos)
 
     QAction openLevel(tr("Open In Level Editor"), this);
     QAction sarcExplorer(tr("Open In Sarc Explorer"), this);
-    QAction fileExplorer(tr("Open In File Explorer"), this);
+    QAction fileExplorer(tr("Show In File Explorer"), this);
     QAction removeLevel(tr("Remove Level"), this);
 
     connect(&openLevel, SIGNAL(triggered()), this, SLOT(openLevelFromConextMenu()));
     connect(&sarcExplorer, SIGNAL(triggered()), this, SLOT(openInSarcExplorer()));
-    connect(&fileExplorer, SIGNAL(triggered()), this, SLOT(openInFileExplorer()));
+    connect(&fileExplorer, SIGNAL(triggered()), this, SLOT(showInFileExplorer()));
     connect(&removeLevel, SIGNAL(triggered()), this, SLOT(on_removeLevelBtn_clicked()));
 
     openLevel.setData(QVariant(pos));
     sarcExplorer.setData(QVariant(pos));
+    fileExplorer.setData(QVariant(pos));
 
     contextMenu.addAction(&openLevel);
     contextMenu.addAction(&sarcExplorer);
@@ -555,16 +556,17 @@ void MainWindow::createTilesetListContextMenu(const QPoint &pos)
 
     QAction openTileset(tr("Open In Tileset Editor"), this);
     QAction sarcExplorer(tr("Open In Sarc Explorer"), this);
-    QAction fileExplorer(tr("Open In File Explorer"), this);
+    QAction fileExplorer(tr("Show In File Explorer"), this);
     QAction removeTileset(tr("Remove Tileset"), this);
 
     connect(&openTileset, SIGNAL(triggered()), this, SLOT(openTilesetFromConextMenu()));
     connect(&sarcExplorer, SIGNAL(triggered()), this, SLOT(openInSarcExplorer()));
-    connect(&fileExplorer, SIGNAL(triggered()), this, SLOT(openInFileExplorer()));
+    connect(&fileExplorer, SIGNAL(triggered()), this, SLOT(showInFileExplorer()));
     connect(&removeTileset, SIGNAL(triggered()), this, SLOT(on_removeTilesetBtn_clicked()));
 
     openTileset.setData(QVariant(pos));
     sarcExplorer.setData(QVariant(pos));
+    fileExplorer.setData(QVariant(pos));
 
     contextMenu.addAction(&openTileset);
     contextMenu.addAction(&sarcExplorer);
@@ -607,7 +609,7 @@ void MainWindow::openInSarcExplorer()
     sarcExplorer->show();
 }
 
-void MainWindow::openInFileExplorer()
+void MainWindow::showInFileExplorer()
 {
     QAction* action = qobject_cast<QAction*>(sender());
     QString path = getFilePath(action);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -636,6 +636,17 @@ void MainWindow::showInFileExplorer()
     args << "return";
     if (!QProcess::execute("/usr/bin/osascript", args))
         return;
+#elif defined(Q_OS_LINUX)
+    QStringList args;
+    args << "--session";
+    args << "--dest=org.freedesktop.FileManager1";
+    args << "--type=method_call";
+    args << "/org/freedesktop/FileManager1";
+    args << "org.freedesktop.FileManager1.ShowItems";
+    args << "array:string:file://" + path;
+    args << "string:";
+    if (QProcess::startDetached("dbus-send", args))
+        return;
 #endif
     QDesktopServices::openUrl(QUrl::fromLocalFile(info.isDir()? path : info.path()));
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -84,6 +84,8 @@ private slots:
 
     void openInSarcExplorer();
 
+    void openInFileExplorer();
+
 private:
     Ui::MainWindow *ui;
 
@@ -102,6 +104,8 @@ private:
     void setNightmode(bool nightmode);
 
     void changeEvent(QEvent* event);
+
+    QString getFilePath(QAction* action);
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -83,8 +83,8 @@ private slots:
     void openTilesetFromConextMenu();
 
     void openInSarcExplorer();
-
-    void openInFileExplorer();
+    
+    void showInFileExplorer();
 
 private:
     Ui::MainWindow *ui;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -198,7 +198,7 @@
      <x>0</x>
      <y>0</y>
      <width>436</width>
-     <height>22</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/resource/translations/English.ts
+++ b/resource/translations/English.ts
@@ -672,6 +672,10 @@ Connection to %1 failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show In File Explorer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
1. Right click any level or tileset in the main window
2. Choose "Show in File Explorer"
3. Your system's file explorer will open, and the file will be selected

Works on all operating systems, including almost all Linux users.